### PR TITLE
Fix SkillFramework infinite skill point

### DIFF
--- a/SkillFramework/BepInExPlugin.cs
+++ b/SkillFramework/BepInExPlugin.cs
@@ -150,7 +150,7 @@ namespace SkillFramework
 
                 bool reduce = Chainloader.PluginInfos.ContainsKey("aedenthorn.Respec") && AedenthornUtils.CheckKeyHeld(Chainloader.PluginInfos["aedenthorn.Respec"].Instance.Config[new ConfigDefinition("Options", "ModKey")].BoxedValue as string);
 
-                // avoid increasing point when not skill points are available
+                // avoid increasing point when no skill points are available
                 if (Global.code.uiCharacter.curCustomization.GetComponent<ID>().skillPoints == 0 && !reduce)
                     return false;
 

--- a/SkillFramework/BepInExPlugin.cs
+++ b/SkillFramework/BepInExPlugin.cs
@@ -150,12 +150,20 @@ namespace SkillFramework
 
                 bool reduce = Chainloader.PluginInfos.ContainsKey("aedenthorn.Respec") && AedenthornUtils.CheckKeyHeld(Chainloader.PluginInfos["aedenthorn.Respec"].Instance.Config[new ConfigDefinition("Options", "ModKey")].BoxedValue as string);
 
-                foreach(SkillInfo info in customSkills.Values)
+                // avoid increasing point when not skill points are available
+                if (Global.code.uiCharacter.curCustomization.GetComponent<ID>().skillPoints == 0 && !reduce)
+                    return false;
+
+                foreach (SkillInfo info in customSkills.Values)
                 {
                     if(info.id == __instance.name)
                     {
                         Dbgl($"{(reduce ?"Reducing": "Increasing")} skill {__instance.name} {characterSkillLevels[Global.code.uiCharacter.curCustomization.name][__instance.name]}");
                         GetCharacterSkillLevel(Global.code.uiCharacter.curCustomization.name, __instance.name);
+
+                        // avoid increasing skills maximum points are reached for the current skill
+                        if (__instance.points == __instance.maxPoints && !reduce)
+                            return false;
 
                         if (reduce)
                         {


### PR DESCRIPTION
Hello @aedenthorn,

I've been trying the SkillFramework as well as your mods that work with it (e.g. MovementSpeedSkill) and found that by just clicking a custom skill you were able to add infinite skill points to them (you need to re-open the character screen to see the changes after clicks).

Since I've started modding recently using the SkillFramework, I thought it would be good to fix this (So I can rely on the original code instead of a copy of yours with the modification).