### PR TITLE
Simplify boolean expressions (flag == true -> flag, etc)

### DIFF
--- a/BepInExModSupport/BepInExPlugin.cs
+++ b/BepInExModSupport/BepInExPlugin.cs
@@ -308,7 +308,7 @@ namespace BepInExModSupport
                 
 
 
-                if (!mainMenu && Mainframe.code?.uiModBrowse.gameObject.activeSelf != true)
+                if (!mainMenu && !Mainframe.code?.uiModBrowse.gameObject.activeSelf)
                 {
                     isCheckingUpdates = false;
                     yield break;
@@ -387,7 +387,7 @@ namespace BepInExModSupport
                             check = true;
                         }
                     }
-                    if (found == false)
+                    if (!found)
                     {
                         Dbgl("Mod version string not found on page!");
                         //File.WriteAllLines(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), id + "_page.txt"), lines);

--- a/CompareEquipment/BepInExPlugin.cs
+++ b/CompareEquipment/BepInExPlugin.cs
@@ -55,7 +55,7 @@ namespace CompareEquipment
         {
             static void Postfix(UICombat __instance)
             {
-                if (!modEnabled.Value || __instance.descriptionsPanel?.gameObject.activeSelf != true)
+                if (!modEnabled.Value || !__instance.descriptionsPanel?.gameObject.activeSelf)
                     return;
 
                 if (AedenthornUtils.CheckKeyDown(weaponModKey.Value) || AedenthornUtils.CheckKeyUp(weaponModKey.Value))

--- a/ConfigurationManager/BepInExPlugin.cs
+++ b/ConfigurationManager/BepInExPlugin.cs
@@ -584,11 +584,11 @@ namespace ConfigurationManager
             else
             {
                 if (!_showAdvanced.Value)
-                    results = results.Where(x => x.IsAdvanced != true);
+                    results = results.Where(x => !x.IsAdvanced);
                 if (!_showKeybinds.Value)
                     results = results.Where(x => !IsKeyboardShortcut(x));
                 if (!_showSettings.Value)
-                    results = results.Where(x => x.IsAdvanced == true || IsKeyboardShortcut(x));
+                    results = results.Where(x => x.IsAdvanced || IsKeyboardShortcut(x));
             }
 
             const string shortcutsCatName = "Keyboard shortcuts";

--- a/ConfigurationManager/LegacySettingEntry.cs
+++ b/ConfigurationManager/LegacySettingEntry.cs
@@ -61,7 +61,7 @@ namespace ConfigurationManager
                     return null;
                 }
 
-                entry.Browsable = innerProp.CanRead && innerProp.CanWrite && entry.Browsable != false;
+                entry.Browsable = innerProp.CanRead && innerProp.CanWrite && entry.Browsable;
 
                 entry.Property = innerProp;
                 entry.Instance = wrapper;

--- a/ConfigurationManager/SettingEntryBase.cs
+++ b/ConfigurationManager/SettingEntryBase.cs
@@ -111,7 +111,7 @@ namespace ConfigurationManager
         /// </summary>
         public void Set(object newVal)
         {
-            if (ReadOnly != true)
+            if (!ReadOnly)
                 SetValue(newVal);
         }
 

--- a/ConfigurationManager/SettingFieldDrawer.cs
+++ b/ConfigurationManager/SettingFieldDrawer.cs
@@ -238,7 +238,7 @@ namespace ConfigurationManager
                 setting.Set(newValue);
             }
 
-            if (setting.ShowRangeAsPercent == true)
+            if (setting.ShowRangeAsPercent)
             {
                 DrawCenteredLabel(
                     Mathf.Round(100 * Mathf.Abs(result - leftValue) / Mathf.Abs(rightValue - leftValue)) + "%",

--- a/ConfigurationManager/SettingSearcher.cs
+++ b/ConfigurationManager/SettingSearcher.cs
@@ -46,7 +46,7 @@ namespace ConfigurationManager
 
                 //BepInExPlugin.Dbgl(plugin.name);
 
-                if (plugin.Info.Metadata.GUID == "com.bepis.bepinex.configurationmanager" || plugin.enabled == false)
+                if (plugin.Info.Metadata.GUID == "com.bepis.bepinex.configurationmanager" || !plugin.enabled)
                 {
                     BepInExPlugin.Dbgl($"plugin: {plugin.Info.Metadata.Name} enabled {plugin.enabled}");
                 }
@@ -68,11 +68,11 @@ namespace ConfigurationManager
 
                 detected.AddRange(GetPluginConfig(plugin).Cast<SettingEntryBase>());
 
-                int count = detected.FindAll(x => x.Browsable == false).Count;
+                int count = detected.FindAll(x => !x.Browsable).Count;
                 if(count > 0)
                 {
                     BepInExPlugin.Dbgl($"{count} settings are not browseable, removing.");
-                    detected.RemoveAll(x => x.Browsable == false);
+                    detected.RemoveAll(x => !x.Browsable);
                 }
 
                 if (!detected.Any())

--- a/CustomMainMenu/BepInExPlugin.cs
+++ b/CustomMainMenu/BepInExPlugin.cs
@@ -101,19 +101,19 @@ namespace CustomMainMenu
 
         private void LightSettingChanged(object sender, EventArgs e)
         {
-            if (SceneManager.GetActiveScene().name == "Desktop" && mmCharacter?.gameObject.activeSelf == true)
+            if (SceneManager.GetActiveScene().name == "Desktop" && mmCharacter?.gameObject.activeSelf)
                 LoadCustomLightData();
         }
 
         private void PoseSettingChanged(object sender, EventArgs e)
         {
-            if (SceneManager.GetActiveScene().name == "Desktop" && mmCharacter?.gameObject.activeSelf == true)
+            if (SceneManager.GetActiveScene().name == "Desktop" && mmCharacter?.gameObject.activeSelf)
                 LoadPoseData();
         }
         
         private void SettingChanged(object sender, EventArgs e)
         {
-            if (SceneManager.GetActiveScene().name == "Desktop" && mmCharacter?.gameObject.activeSelf == true)
+            if (SceneManager.GetActiveScene().name == "Desktop" && mmCharacter?.gameObject.activeSelf)
                 LoadCustomCharacter();
         }
     }

--- a/CustomPortrait/BepInExPlugin.cs
+++ b/CustomPortrait/BepInExPlugin.cs
@@ -80,7 +80,7 @@ namespace CustomPortrait
 
             if (AedenthornUtils.CheckKeyDown(hotkey.Value))
             {
-                if ((AedenthornUtils.CheckKeyHeld(portraitModkey.Value, true) || (AedenthornUtils.CheckKeyHeld(portraitModkey.Value, false) && !AedenthornUtils.CheckKeyHeld(screenshotModkey.Value, true))) && (Global.code.uiInventory.gameObject.activeSelf == true || Global.code.uiPose.gameObject.activeSelf == true || Global.code.uiFreePose.gameObject.activeSelf == true))
+                if ((AedenthornUtils.CheckKeyHeld(portraitModkey.Value, true) || (AedenthornUtils.CheckKeyHeld(portraitModkey.Value, false) && !AedenthornUtils.CheckKeyHeld(screenshotModkey.Value, true))) && (Global.code.uiInventory.gameObject.activeSelf || Global.code.uiPose.gameObject.activeSelf || Global.code.uiFreePose.gameObject.activeSelf))
                 {
                     Dbgl("Pressed portrait hotkey");
 

--- a/DebugMenu/Patches.cs
+++ b/DebugMenu/Patches.cs
@@ -151,7 +151,7 @@ namespace DebugMenu
         {
             public static bool Prefix()
             {
-                if (!modEnabled.Value || uiSpawnItem?.gameObject.activeSelf != true)
+                if (!modEnabled.Value || !uiSpawnItem?.gameObject.activeSelf)
                     return true;
                 return false;
             }
@@ -163,7 +163,7 @@ namespace DebugMenu
         {
             public static bool Prefix()
             {
-                if (!modEnabled.Value || (uiDebug?.gameObject.activeSelf != true && uiSpawnItem?.gameObject.activeSelf != true))
+                if (!modEnabled.Value || (!uiDebug?.gameObject.activeSelf && !uiSpawnItem?.gameObject.activeSelf))
                     return true;
 
                 Global.code.uiCombat.HideHint();
@@ -275,7 +275,7 @@ namespace DebugMenu
                 __instance.rigidbody.useGravity = !flyMode.Value;
                 __instance.GetComponent<CapsuleCollider>().enabled = !flyMode.Value;
 
-                if (!Global.code.onGUI && spawnInput?.gameObject.activeSelf != true && AedenthornUtils.CheckKeyDown(flyToggleKey.Value))
+                if (!Global.code.onGUI && !spawnInput?.gameObject.activeSelf && AedenthornUtils.CheckKeyDown(flyToggleKey.Value))
                     flyMode.Value = !flyMode.Value;
 
                 if (flyMode.Value)

--- a/EnemySuccubi/BepInExPlugin.cs
+++ b/EnemySuccubi/BepInExPlugin.cs
@@ -78,7 +78,7 @@ namespace EnemySuccubi
         {
             public static void Postfix(EnemySpawner __instance, ref Transform __result)
             {
-                if (!modEnabled.Value || __result.GetComponent<Monster>()?.isElite == true)
+                if (!modEnabled.Value || __result.GetComponent<Monster>()?.isElite)
                     return;
 
                 if (TrySpawnOrdinary(__result))

--- a/EnhancedFreePose/BepInExPlugin.cs
+++ b/EnhancedFreePose/BepInExPlugin.cs
@@ -238,7 +238,7 @@ namespace EnhancedFreePose
         {
             public static void Prefix(FreelookCamera __instance)
             {
-                if (!modEnabled.Value || Global.code?.uiFreePose.gameObject.activeSelf != true)
+                if (!modEnabled.Value || !Global.code?.uiFreePose.gameObject.activeSelf)
                     return;
                 __instance.Speed = freeCameraSpeed.Value;
                 __instance.BoostSpeed = freeCameraSpeed.Value * freeCameraBoostMult.Value;
@@ -262,7 +262,7 @@ namespace EnhancedFreePose
             {
                 try
                 {
-                    if (!modEnabled.Value || Global.code?.uiFreePose?.gameObject?.activeSelf != true || ___mytransform == null)
+                    if (!modEnabled.Value || !Global.code?.uiFreePose?.gameObject?.activeSelf || ___mytransform == null)
                         return;
                 }
                 catch { return; }
@@ -273,7 +273,7 @@ namespace EnhancedFreePose
             {
                 try
                 {
-                    if (!modEnabled.Value || Global.code?.uiFreePose?.gameObject?.activeSelf != true || !___mytransform || __state == null)
+                    if (!modEnabled.Value || !Global.code?.uiFreePose?.gameObject?.activeSelf || !___mytransform || __state == null)
                         return;
                 }
                 catch

--- a/RescueMissions/BepInExPlugin.cs
+++ b/RescueMissions/BepInExPlugin.cs
@@ -53,7 +53,7 @@ namespace RescueMissions
                     if (transform)
                     {
                         Location location = transform.GetComponent<Location>();
-                        if (location && location.locationType == LocationType.rescue && !location.companionPrisoner && location.level <= Player.code._ID.level && transform.parent?.gameObject.activeSelf == true && Random.value < rescueMissionChance.Value)
+                        if (location && location.locationType == LocationType.rescue && !location.companionPrisoner && location.level <= Player.code._ID.level && transform.parent?.gameObject.activeSelf && Random.value < rescueMissionChance.Value)
                         {
                             Dbgl("Trying to add rescue companion");
 

--- a/Resurrection/BepInExPlugin.cs
+++ b/Resurrection/BepInExPlugin.cs
@@ -88,7 +88,7 @@ namespace Resurrection
                             resurrectSkill.gameObject.name = "Resurrection Spell";
                             resurrectSkill.manaConsumption = manaCost.Value;
                         }
-                        IEnumerable<Transform> deadCompanions = FindObjectsOfType<Companion>().ToList().FindAll(t => t.GetComponent<Companion>() && t.GetComponent<ID>()?.isFriendly == true && t.gameObject.tag == "D").Select(c => c.transform);
+                        IEnumerable<Transform> deadCompanions = FindObjectsOfType<Companion>().ToList().FindAll(t => t.GetComponent<Companion>() && t.GetComponent<ID>()?.isFriendly && t.gameObject.tag == "D").Select(c => c.transform);
                         deadCompanion = null;
                         if (deadCompanions.Any())
                         {

--- a/SkillFramework/SkillAPI.cs
+++ b/SkillFramework/SkillAPI.cs
@@ -26,7 +26,7 @@ namespace SkillFramework
                 reqLevel = reqLevel,
                 isActiveSkill = isActiveSkill
             };
-            if (Global.code?.uiCharacter?.gameObject.activeSelf == true)
+            if (Global.code?.uiCharacter?.gameObject.activeSelf)
                 Global.code.uiCharacter.Refresh();
         }
         public static SkillInfo GetSkill(string id)


### PR DESCRIPTION
# Description

This patch does exactly one thing: it reduces boolean expression clutter. There are no functional changes.

# Motivation

* `flag == true` -> `flag`: There's no reason to include "== true" in a boolean expression. There is never any reason to compare a boolean expression to a boolean constant. It is always redundant.
* `flag != false` -> `flag`: This is the double-negative version of the first point.
* `flag != true` and `flag == false` -> `!flag`: The single negative versions of the first two. The not operator exists for a reason. `! enabled` makes so much more sense than `enabled != true` or `enabled == false`

My editor (Vim) also added new-lines to the ends of files which didn't have them. I hope that's not a problem.

# Testing

None. The project has no test framework and in-game testing would be a logistical .. challenge. I welcome tips on how to simplify testing of SWPT mod changes. It takes five minutes to start the game, load a save and get into a battle. I can't imagine how long it would take to install the mods I touched and test them all in-game.

What I'm saying is, this project needs a test framework so I can write and run tests before making code changes. Maybe that will be my next PR...